### PR TITLE
Refactors CLI to use `exec` command

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,542 @@
+# API Design
+This document outlines the design principles and structure for the `gemdock` command-line interface (CLI).
+
+## Command structure
+
+```
+gemdock [global-options] <command> [command-options] [arguments]
+```
+
+examples:
+```bash
+gemdock exec gem install bundler 2.4.22
+gemdock exec rspec spec/
+gemdock exec shell   # Opens an interactive shell
+```
+
+## Execute Commands in Container
+
+This gem generates a `docker-compose.yml` file in the user home folder `$HOME/.gemdock`
+
+## Execute Arbitrary Commands
+
+To execute arbitrary commands, use `gemdock exec <arbitrary-command>`.
+This allows users to run any command inside the container
+
+### Examples
+
+```bash
+gemdock exec gem install bundler 2.4.22
+gemdock exec -- ls -la         # When command starts with dash
+gemdock exec ruby script.rb    # No double dash needed
+```
+
+### interactive shell 
+To open an interactive shell inside the container, use:
+```bash
+gemdock exec shell
+```
+
+# Inspiration
+This gem is inspired by https://github.com/bibendi/dip tool.
+Following is what `dip` README says about itself:
+<readme>
+[![Gem Version](https://badge.fury.io/rb/dip.svg)](https://badge.fury.io/rb/dip)
+[![Build Status](https://github.com/bibendi/dip/actions/workflows/ci.yml/badge.svg)](https://github.com/bibendi/dip/actions/workflows/ci.yml)
+[![Maintainability](https://api.codeclimate.com/v1/badges/d0dca854f0930502f7b3/maintainability)](https://codeclimate.com/github/bibendi/dip/maintainability)
+
+<img src="https://raw.githubusercontent.com/bibendi/dip/master/.github/logo.png" alt="dip logo" height="140" />
+
+The dip is a CLI dev–tool that provides native-like interaction with a Dockerized application. It gives the feeling that you are working without using mind-blowing commands to run containers.
+
+<a href="https://evilmartians.com/?utm_source=dip">
+<img src="https://evilmartians.com/badges/sponsored-by-evil-martians.svg" alt="Sponsored by Evil Martians" height="80" /></a>
+
+## Presentations and examples
+
+- [Local development with Docker containers](https://slides.com/bibendi/dip)
+- [Dockerized Ruby on Rails application](https://github.com/Kuper-Tech/outbox-example-apps)
+- Dockerized Node.js application: [one](https://github.com/bibendi/twinkle.js), [two](https://github.com/bibendi/yt-graphql-react-event-booking-api)
+- [Dockerized Ruby gem](https://github.com/bibendi/schked)
+- [Dockerizing Ruby and Rails development](https://evilmartians.com/chronicles/ruby-on-whales-docker-for-ruby-rails-development)
+- [Reusable development containers with Docker Compose and Dip](https://evilmartians.com/chronicles/reusable-development-containers-with-docker-compose-and-dip)
+
+[![asciicast](https://asciinema.org/a/210236.svg)](https://asciinema.org/a/210236)
+
+## Installation
+
+```sh
+gem install dip
+```
+
+### Integration with shell
+
+Dip can be injected into the current shell (ZSH or Bash).
+
+```sh
+eval "$(dip console)"
+```
+
+**IMPORTANT**: Beware of possible collisions with local tools. One particular example is supporting both local and Docker frontend build tools, such as Yarn. If you want some developer to run `yarn` locally and other to use Docker for that, you should either avoid adding the `yarn` command to the `dip.yml` or avoid using the shell integration for hybrid development.
+
+After that we can type commands without `dip` prefix. For example:
+
+```sh
+<run-command> *any-args
+compose *any-compose-arg
+up <service>
+ktl *any-kubectl-arg
+provision
+```
+
+When we change the current directory, all shell aliases will be automatically removed. But when we enter back into a directory with a `dip.yml` file, then shell aliases will be renewed.
+
+Also, in shell mode Dip is trying to determine manually passed environment variables. For example:
+
+```sh
+VERSION=20180515103400 rails db:migrate:down
+```
+
+You could add this `eval` at the end of your `~/.zshrc`, or `~/.bashrc`, or `~/.bash_profile`.
+After that, it will be automatically applied when you open your preferred terminal.
+
+## Usage
+
+```sh
+dip --help
+dip SUBCOMMAND --help
+```
+
+### dip.yml
+
+The configuration is loaded from `dip.yml` file. It may be located in a working directory, or it will be found in the nearest parent directory up to the file system root. If nearby places `dip.override.yml` file, it will be merged into the main config.
+
+Also, in some cases, you may want to change the default config path by providing an environment variable `DIP_FILE`.
+
+Below is an example of a real config.
+Config file reference will be written soon.
+Also, you can check out examples at the top.
+
+```yml
+# Required minimum dip version
+version: '8.0'
+
+environment:
+  COMPOSE_EXT: development
+  STAGE: "staging"
+
+compose:
+  files:
+    - docker/docker-compose.yml
+    - docker/docker-compose.$COMPOSE_EXT.yml
+    - docker/docker-compose.$DIP_OS.yml
+  project_name: bear
+
+kubectl:
+  namespace: rocket-$STAGE
+
+interaction:
+  shell:
+    description: Open the Bash shell in app's container
+    service: app
+    command: bash
+    compose:
+      run_options: [no-deps]
+
+  bundle:
+    description: Run Bundler commands
+    service: app
+    command: bundle
+
+  rake:
+    description: Run Rake commands
+    service: app
+    command: bundle exec rake
+
+  rspec:
+    description: Run Rspec commands
+    service: app
+    environment:
+      RAILS_ENV: test
+    command: bundle exec rspec
+
+  rails:
+    description: Run Rails commands
+    service: app
+    command: bundle exec rails
+    subcommands:
+      s:
+        description: Run Rails server at http://localhost:3000
+        service: web
+        compose:
+          run_options: [service-ports, use-aliases]
+
+  stack:
+    description: Run full stack (server, workers, etc.)
+    runner: docker_compose
+    compose:
+      profiles: [web, workers]
+
+  sidekiq:
+    description: Run sidekiq in background
+    service: worker
+    compose:
+      method: up
+      run_options: [detach]
+
+  psql:
+    description: Run Postgres psql console
+    service: app
+    default_args: db_dev
+    command: psql -h pg -U postgres
+
+  k:
+    description: Run commands in Kubernetes cluster
+    pod: svc/rocket-app:app-container
+    entrypoint: /env-entrypoint
+    subcommands:
+      bash:
+        description: Get a shell to the running container
+        command: /bin/bash
+      rails:
+        description: Run Rails commands
+        command: bundle exec rails
+      kafka-topics:
+        description: Manage Kafka topics
+        pod: svc/rocket-kafka
+        command: kafka-topics.sh --zookeeper zookeeper:2181
+
+  setup_key:
+    description: Copy key
+    service: app
+    command: cp `pwd`/config/key.pem /root/keys/
+    shell: false # you can disable shell interpolations on the host machine and send the command as is
+
+  clean_cache:
+    description: Delete cache files on the host machine
+    command: rm -rf $(pwd)/tmp/cache/*
+
+provision:
+  - dip compose down --volumes
+  - dip clean_cache
+  - dip compose up -d pg redis
+  - dip bash -c ./bin/setup
+```
+
+### Predefined environment variables
+
+#### $DIP_OS
+
+Current OS architecture (e.g. `linux`, `darwin`, `freebsd`, and so on). Sometime it may be useful to have one common `docker-compose.yml` and OS-dependent Compose configs.
+
+#### $DIP_WORK_DIR_REL_PATH
+
+Relative path from the current directory to the nearest directory where a Dip's config is found. It is useful when you need to mount a specific local directory to a container along with ability to change its working dir. For example:
+
+```
+- project_root
+  |- dip.yml (1)
+  |- docker-compose.yml (2)
+  |- sub-project-dir
+     |- your current directory is here <<<
+```
+
+```yml
+# dip.yml (1)
+environment:
+  WORK_DIR: /app/${DIP_WORK_DIR_REL_PATH}
+```
+
+```yml
+# docker-compose.yml (2)
+services:
+  app:
+    working_dir: ${WORK_DIR:-/app}
+```
+
+```sh
+cd sub-project-dir
+dip run bash -c pwd
+```
+
+returned is `/app/sub-project-dir`.
+
+#### $DIP_CURRENT_USER
+
+Exposes the current user ID (UID). It is useful when you need to run a container with the same user as the host machine. For example:
+
+```yml
+# dip.yml (1)
+environment:
+  UID: ${DIP_CURRENT_USER}
+```
+
+```yml
+# docker-compose.yml (2)
+services:
+  app:
+    image: ruby
+    user: ${UID:-1000}
+```
+
+The container will run using the same user ID as your host machine.
+
+### Modules
+
+Modules are defined as array in `modules` section of dip.yml, modules are stored in `.dip` subdirectory of dip.yml directory.
+
+The main purpose of modules is to improve maintainability for a group of projects.
+Imagine having multiple gems which are managed with dip, each of them has the same commands, so to change one command in dip you need to update all gems individualy.
+
+With `modules` you can define a group of modules for dip.
+
+For example having setup as this:
+
+```yml
+# ./dip.yml
+modules:
+ - sasts
+ - rails
+
+...
+```
+
+```yml
+# ./.dip/sasts.yml
+interaction:
+  brakeman:
+    description: Check brakeman sast
+    command: docker run ...
+```
+
+```yml
+# ./.dip/rails.yml
+interaction:
+  annotate:
+    description: Run annotate command
+    service: backend
+    command: bundle exec annotate
+```
+
+Will be expanded to:
+
+```yml
+# resultant configuration
+interaction:
+  brakeman:
+    description: Check brakeman sast
+    command: docker run ...
+  annotate:
+    description: Run annotate command
+    service: backend
+    command: bundle exec annotate
+```
+
+Imagine `.dip` to be a submodule so it can be managed only in one place.
+
+If you want to override module command, you can redefine it in dip.yml
+
+```yml
+# ./dip.yml
+modules:
+ - sasts
+
+interaction:
+  brakeman:
+    description: Check brakeman sast
+    command: docker run another-image ...
+```
+
+```yml
+# ./.dip/sasts.yml
+interaction:
+  brakeman:
+    description: Check brakeman sast
+    command: docker run some-image ...
+```
+
+Will be expanded to:
+
+```yml
+# resultant configuration
+interaction:
+  brakeman:
+    description: Check brakeman sast
+    command: docker run another-image ...
+```
+
+Nested modules are not supported.
+
+### dip run
+
+Run commands defined within the `interaction` section of dip.yml
+
+A command will be executed by specified runner. Dip has three types of them:
+
+- `docker compose` runner — used when the `service` option is defined.
+- `kubectl` runner — used when the `pod` option is defined.
+- `local` runner — used when the previous ones are not defined.
+
+```sh
+dip run rails c
+dip run rake db:migrate
+```
+
+Also, `run` argument can be omitted
+
+```sh
+dip rake db:migrate
+```
+
+You can pass in a custom environment variable into a container:
+
+```sh
+dip VERSION=12352452 rake db:rollback
+```
+
+Use options `-p, --publish=[]` if you need to additionally publish a container's port(s) to the host unless this behaviour is not configured at dip.yml:
+
+```sh
+dip run -p 3000:3000 bundle exec rackup config.ru
+```
+
+You can also override docker compose command by passing `DIP_COMPOSE_COMMAND` if you wish. For example if you want to use [`mutagen-compose`](https://mutagen.io/documentation/orchestration/compose) run `DIP_COMPOSE_COMMAND=mutagen-compose dip run`.
+
+If you want to persist that change you can specify command in `compose` section of dip.yml :
+
+```yml
+compose:
+  command: mutagen-compose
+
+```
+
+### dip ls
+
+List all available run commands.
+
+```sh
+dip ls
+
+bash     # Open the Bash shell in app's container
+rails    # Run Rails command
+rails s  # Run Rails server at http://localhost:3000
+```
+
+### dip provision
+
+Run commands each by each from `provision` section of dip.yml
+
+### dip compose
+
+Run Docker Compose commands that are configured according to the application's dip.yml:
+
+```sh
+dip compose COMMAND [OPTIONS]
+
+dip compose up -d redis
+```
+
+### dip infra
+
+Runs shared Docker Compose services that are used by the current application. Useful for microservices.
+
+There are several official infrastructure services available:
+- [dip-postgres](https://github.com/bibendi/dip-postgres)
+- [dip-kafka](https://github.com/bibendi/dip-kafka)
+- [dip-nginx](https://github.com/bibendi/dip-nginx)
+
+```yaml
+# dip.yml
+infra:
+  foo:
+    git: https://github.com/owner/foo.git
+    ref: latest # default, optional
+  bar:
+    path: ~/path/to/bar
+```
+
+Repositories will be pulled to a `~/.dip/infra` folder. For example, for the `foo` service it would be like this: `~/.dip/infra/foo/latest` and clonned with the following command: `git clone -b <ref> --single-branch <git> --depth 1`.
+
+Available CLI commands:
+
+- `dip infra update` pulls updates from sources
+- `dip infra up` starts all infra services
+- `dip infra up -n kafka` starts a specific infra service
+- `dip infra down` stops all infra services
+- `dip infra down -n kafka` stops a specific infra service
+
+### dip ktl
+
+Run kubectl commands that are configured according to the application's dip.yml:
+
+```sh
+dip ktl COMMAND [OPTIONS]
+
+STAGE=some dip ktl get pods
+```
+
+### dip ssh
+
+Runs ssh-agent container based on https://github.com/whilp/ssh-agent with your ~/.ssh/id_rsa.
+It creates a named volume `ssh_data` with ssh socket.
+An application's docker-compose.yml should contains environment variable `SSH_AUTH_SOCK=/ssh/auth/sock` and connects to external volume `ssh_data`.
+
+```sh
+dip ssh up
+```
+
+docker-compose.yml
+
+```yml
+services:
+  web:
+    environment:
+      - SSH_AUTH_SOCK=/ssh/auth/sock
+    volumes:
+      - ssh-data:/ssh:ro
+
+volumes:
+  ssh-data:
+    external:
+      name: ssh_data
+```
+
+if you want to use non-root user you can specify UID like so:
+
+```
+dip ssh up -u 1000
+```
+
+This especially helpful if you have something like this in your docker-compose.yml:
+
+```yml
+services:
+  web:
+    user: "1000:1000"
+```
+
+### dip validate
+
+Validates your dip.yml configuration against the JSON schema. The schema validation helps ensure your configuration is correct and follows the expected format.
+
+```sh
+dip validate
+```
+
+The validator will check:
+
+- Required properties are present
+- Property types are correct
+- Values match expected patterns
+- No unknown properties are used
+
+If validation fails, you'll get detailed error messages indicating what needs to be fixed.
+
+You can skip validation by setting `DIP_SKIP_VALIDATION` environment variable.
+
+Add `# yaml-language-server: $schema=https://raw.githubusercontent.com/bibendi/dip/refs/heads/master/schema.json` to the top of your dip.yml to get schema validation in VSCode. Read more about [YAML Language Server](https://github.com/redhat-developer/vscode-yaml?tab=readme-ov-file#associating-schemas).
+
+## Changelog
+
+https://github.com/bibendi/dip/releases
+</readme>

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,11 +12,19 @@ examples:
 gemdock exec gem install bundler 2.4.22
 gemdock exec rspec spec/
 gemdock exec shell   # Opens an interactive shell
+gemdock exec --ruby-version 3.2.0 bundle gem myproject
+gemdock exec --ruby-version 2.7.0 rspec spec/
 ```
 
 ## Execute Commands in Container
 
 This gem generates a `docker-compose.yml` file in the user home folder `$HOME/.gemdock`
+
+When using the `--ruby-version` flag, GemDock creates version-specific configuration files and volumes:
+- Configuration: `$HOME/.gemdock/docker-compose-ruby-<version>.yml`
+- Volume: `bundler_data_ruby_<version>`
+
+This allows you to work with multiple Ruby versions simultaneously without conflicts.
 
 ## Execute Arbitrary Commands
 
@@ -31,10 +39,47 @@ gemdock exec -- ls -la         # When command starts with dash
 gemdock exec ruby script.rb    # No double dash needed
 ```
 
+## Ruby Version Selection
+
+You can specify a Ruby version for any command using the `--ruby-version` (or `-r`) flag:
+
+```bash
+# Create a new gem with Ruby 3.2.0
+gemdock exec --ruby-version 3.2.0 bundle gem myproject
+
+# Run tests with Ruby 2.7.0
+gemdock exec --ruby-version 2.7.0 rspec spec/
+
+# Default behavior (uses latest stable Ruby)
+gemdock exec bundle install
+```
+
+### Version-Specific Volumes
+
+Each Ruby version gets its own isolated bundle cache volume. This ensures:
+- ✅ No gem conflicts between Ruby versions
+- ✅ Native extensions are compiled for the correct Ruby version
+- ✅ Fast switching between versions (volumes are cached)
+
+Example:
+```bash
+# First time with Ruby 3.3 - installs gems to bundler_data_ruby_3_3_0
+gemdock exec --ruby-version 3.3.0 bundle install
+
+# First time with Ruby 2.7 - installs gems to bundler_data_ruby_2_7_0
+gemdock exec --ruby-version 2.7.0 bundle install
+
+# Switch back to Ruby 3.3 - reuses cached gems
+gemdock exec --ruby-version 3.3.0 rspec spec/
+```
+
 ### interactive shell 
 To open an interactive shell inside the container, use:
 ```bash
 gemdock exec shell
+
+# Or with a specific Ruby version
+gemdock exec --ruby-version 3.1.0 shell
 ```
 
 # Inspiration

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GemDock
 
-GemDock is a developer tool for managing development environments in Docker.
+GemDock is a developer tool for managing Ruby gem development environments in Docker containers.
 
 ## Installation
 
@@ -10,21 +10,37 @@ Install the gem by executing:
 
 ## Usage
 
-To initialize GemDock in your project:
+GemDock automatically initializes when you first run a command. It creates a `docker-compose.yml` file in `$HOME/.gemdock`.
 
-    $ gemdock init
+### Execute Commands in Container
 
-To provision your development environment:
+To execute arbitrary commands in the container:
 
-    $ gemdock provision
+    $ gemdock exec gem install bundler 2.4.22
+    $ gemdock exec rspec spec/
+    $ gemdock exec ruby script.rb
 
-To get available commands:
+### Interactive Shell
 
-    $ gemdock ls
+To open an interactive shell inside the container:
 
-To run a command:
+    $ gemdock exec shell
 
-    $ gemdock run COMMAND
+### Examples
+
+```bash
+# Install a specific version of bundler
+gemdock exec gem install bundler 2.4.22
+
+# Run tests
+gemdock exec rspec spec/
+
+# Run bundle commands
+gemdock exec bundle install
+
+# Open an interactive shell
+gemdock exec shell
+```
 
 ## Guide
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the gem by executing:
 
 ## Usage
 
-GemDock automatically initializes when you first run a command. It creates a `docker-compose.yml` file in `$HOME/.gemdock`.
+GemDock automatically initializes when you first run a command. It creates docker-compose configuration files in `$HOME/.gemdock`.
 
 ### Execute Commands in Container
 
@@ -20,11 +20,37 @@ To execute arbitrary commands in the container:
     $ gemdock exec rspec spec/
     $ gemdock exec ruby script.rb
 
+### Ruby Version Selection
+
+You can specify a Ruby version for any command using the `--ruby-version` (or `-r`) flag:
+
+    $ gemdock exec --ruby-version 3.2.0 bundle gem myproject
+    $ gemdock exec --ruby-version 2.7.0 rspec spec/
+    $ gemdock exec -r 3.1.0 bundle install
+
+Each Ruby version gets its own isolated bundle cache, so you can work with multiple versions without conflicts:
+
+```bash
+# Work with Ruby 3.3
+gemdock exec --ruby-version 3.3.0 bundle install
+gemdock exec --ruby-version 3.3.0 rspec spec/
+
+# Switch to Ruby 2.7
+gemdock exec --ruby-version 2.7.0 bundle install
+gemdock exec --ruby-version 2.7.0 rspec spec/
+
+# Back to Ruby 3.3 (gems are already cached!)
+gemdock exec --ruby-version 3.3.0 rake test
+```
+
 ### Interactive Shell
 
 To open an interactive shell inside the container:
 
     $ gemdock exec shell
+    
+    # Or with a specific Ruby version
+    $ gemdock exec --ruby-version 3.1.0 shell
 
 ### Examples
 
@@ -32,15 +58,33 @@ To open an interactive shell inside the container:
 # Install a specific version of bundler
 gemdock exec gem install bundler 2.4.22
 
-# Run tests
+# Run tests with default Ruby version
 gemdock exec rspec spec/
 
-# Run bundle commands
-gemdock exec bundle install
+# Run bundle commands with Ruby 3.2.0
+gemdock exec --ruby-version 3.2.0 bundle install
 
-# Open an interactive shell
-gemdock exec shell
+# Create a new gem project with Ruby 3.3.0
+gemdock exec --ruby-version 3.3.0 bundle gem my_awesome_gem
+
+# Open an interactive shell with Ruby 2.7.0
+gemdock exec --ruby-version 2.7.0 shell
 ```
+
+## How It Works
+
+### Version-Specific Volumes
+
+GemDock creates isolated environments for each Ruby version you use:
+
+- **Configuration files**: `$HOME/.gemdock/docker-compose-ruby-<version>.yml`
+- **Bundle cache volumes**: `bundler_data_ruby_<version>`
+
+This ensures that gems compiled for one Ruby version don't conflict with another, and switching between versions is fast after the first initialization.
+
+### Container Lifecycle
+
+Each command runs in a fresh container that is automatically removed after execution. However, your installed gems persist in version-specific Docker volumes, so you don't need to reinstall them every time.
 
 ## Guide
 

--- a/docs/gem-development-with-gemdoc-example.md
+++ b/docs/gem-development-with-gemdoc-example.md
@@ -46,19 +46,7 @@ Gem::Specification.new do |spec|
 end
 ```
 
-### 3. Initialize Gemdock config
-
-```bash
-gemdock init 2.7
-```
-
-### 4. Provision of the development environment:
-
-```bash
-gemdock provision
-```
-
-### 5. Implement the Hola Gem
+### 3. Implement the Hola Gem
 
 Edit `lib/hola.rb`:
 
@@ -110,7 +98,7 @@ class Hola::Translator
 end
 ```
 
-### 6. Add tests in `spec/hola_spec.rb`:
+### 4. Add tests in `spec/hola_spec.rb`:
 
 ```ruby
 RSpec.describe Hola do
@@ -132,18 +120,18 @@ RSpec.describe Hola do
 end
 ```
 
-## 7. Testing
+## 5. Testing
 
-Run the RSpec tests:
+Gemdock will automatically initialize when you first run a command. Run the RSpec tests:
 
 ```bash
-gemdock run rspec
+gemdock exec rspec
 ```
 
-You can also test in IRB:
+You can also test in IRB. Open an interactive shell:
 
 ```bash
-gemdock run bash
+gemdock exec shell
 ```
 
 Inside the container, run `irb`.  
@@ -156,26 +144,23 @@ Hola.hi 'spanish'
 Hola.greet(name: 'World', language: 'spanish')
 ```
 
-## 8. Demonstrate Ruby Version Switching
+## 6. Working with Different Commands
 
-Switch to Ruby 3.3:
+Run bundle install:
 
 ```bash
-gemdock update 3.3
-gemdock provision
-gemdock run rspec
+gemdock exec bundle install
 ```
 
-Switch back to Ruby 2.7:
+Run other gem commands:
 
 ```bash
-gemdock update 2.7
-gemdock provision
-gemdock run rspec
+gemdock exec gem install bundler 2.4.22
+gemdock exec rake -T
 ```
 
 Note: The `.greet` method demonstrates the difference between Ruby 2.7 and 3.x. It's not intended for production use.
 
-This revised version maintains the excellent content of your original while improving formatting and readability. It provides a clear, step-by-step guide to creating a gem with Gemdock, demonstrating version-specific features and Gemdock's version switching capabilities.  
+This revised version provides a clear, step-by-step guide to creating a gem with Gemdock using the new exec-based interface.  
 
 FYI: You can get the source code of this tutorial at [https://github.com/saiqulhaq/hola](https://github.com/saiqulhaq/hola)

--- a/lib/gem_dock/cli.rb
+++ b/lib/gem_dock/cli.rb
@@ -9,120 +9,97 @@ require "json"
 
 module GemDock
   class CLI < Thor
-    class << self
-      # Hackery. Take the run method away from Thor so that we can redefine it.
-      # https://github.com/ddollar/foreman/issues/655#issuecomment-263188152
-      def is_thor_reserved_word?(word, type)
-        return false if word == "run"
+    # class << self
+    #   # Hackery. Take the exec method away from Thor so that we can redefine it.
+    #   # https://github.com/ddollar/foreman/issues/655#issuecomment-263188152
+    #   def is_thor_reserved_word?(word, type)
+    #     return false if word == "exec"
 
-        super
+    #     super
+    #   end
+
+    #   def exit_on_failure?
+    #     true
+    #   end
+    # end
+
+    desc "exec COMMAND [ARGS...]", "Execute arbitrary commands in the container"
+    def exec(*args)
+      if args.empty?
+        puts "Error: No command specified"
+        puts "Usage: gemdock exec <command> [args...]"
+        puts "Example: gemdock exec gem install bundler 2.4.22"
+        puts "         gemdock exec shell  # Opens an interactive shell"
+        exit 1
       end
 
-      def exit_on_failure?
-        true
+      ensure_initialized
+
+      # Handle special 'shell' command
+      if args.first == "shell"
+        run_shell
+      else
+        run_command(args)
       end
     end
 
-    desc "init [RUBY_VERSION]", "Initialize GemDock in the current project"
-    method_option :ruby_version, type: :string, desc: "Ruby version to use in docker compose file. It will check the latest stable version from the internet if not provided."
-    def init(ruby_version = options[:ruby_version])
-      ruby_version = default_ruby_version if ruby_version.nil?
+    private
 
+    def ensure_initialized
+      unless File.exist?(docker_compose_file_path)
+        puts "GemDock not initialized. Initializing with default Ruby version..."
+        initialize_gemdock
+      end
+    end
+
+    def initialize_gemdock(ruby_version = nil)
+      ruby_version ||= default_ruby_version
       create_gemdock_directory
-      create_dip_yml
       create_docker_compose_yml(ruby_version: ruby_version)
       puts "GemDock initialized successfully with Ruby version #{ruby_version}!"
     end
 
-    desc "update", "Update docker-compose.yml file"
-    method_option :ruby_version, type: :string, desc: "Ruby version to use in docker compose file. It will check the latest stable version from the internet if not provided."
-    def update(ruby_version = options[:ruby_version])
-      ruby_version = default_ruby_version if ruby_version.nil?
-      create_docker_compose_yml(ruby_version: ruby_version)
-      puts "docker-compose.yml updated successfully!"
+    def run_shell
+      command = build_docker_compose_command(interactive: true)
+      command << ["run", "--rm", "gem-app", "/bin/bash"]
+      system(*command.flatten)
     end
 
-    desc "provision", "Run dip provision"
-    def provision
-      system("DIP_FILE=#{dip_file_path} dip provision")
+    def run_command(args)
+      command = build_docker_compose_command
+      command << ["run", "--rm", "gem-app", "bash", "-c", args.join(" ")]
+      system(*command.flatten)
     end
 
-    desc "run COMMAND", "Run a dip command"
-    # @param commands [Array] command and parameters to run
-    def run(*commands)
-      escaped_commands = commands.map { |cmd| Shellwords.escape(cmd) }.join(' ')
-      system("DIP_FILE=#{Shellwords.escape(dip_file_path)} dip run #{escaped_commands}")
+    def build_docker_compose_command(interactive: false)
+      cmd = ["docker", "compose"]
+      cmd << ["-f", docker_compose_file_path]
+      
+      if interactive
+        # For interactive shell, we need TTY allocation
+        cmd
+      else
+        cmd
+      end
     end
-
-    desc "ls", "List all available dip commands"
-    def ls
-      system("DIP_FILE=#{dip_file_path} dip ls")
-    end
-
-    private
 
     def create_gemdock_directory
       FileUtils.mkdir_p(gemdock_dir)
     end
 
-    def create_dip_yml
-      File.write(File.join(gemdock_dir, "dip.yml"), dip_yml_content)
-    end
-
     # add an argument to the method to accept Ruby version to use in docker compose file
     def create_docker_compose_yml(ruby_version: default_ruby_version)
-      path = File.join(gemdock_dir, "docker-compose.yml")
+      path = docker_compose_file_path
       content = docker_compose_yml_content(ruby_version: ruby_version)
       File.write(path, content)
     end
 
     def gemdock_dir
-      File.join(ENV["HOME"], ".dip", project_path)
+      File.join(ENV["HOME"], ".gemdock")
     end
 
-    def project_path
-      Dir.pwd.sub("#{ENV["HOME"]}/", "")
-    end
-
-    def dip_file_path
-      File.join(gemdock_dir, "dip.yml")
-    end
-
-    def dip_yml_content
-      <<~YAML
-        version: '8.0'
-
-        compose:
-          files:
-            - docker-compose.yml
-
-        interaction:
-          bash:
-            description: Open the Bash shell in app's container
-            service: gem-app
-            command: /bin/bash
-
-          bundle:
-            description: Run Bundler commands
-            service: gem-app
-            command: bundle
-
-          appraisal:
-            description: Run Appraisal commands
-            service: gem-app
-            command: bundle exec appraisal
-
-          rspec:
-            description: Run Rspec commands
-            service: gem-app
-            command: bundle exec rspec
-
-        provision:
-          - dip compose down --volumes
-          - rm -f Gemfile.lock gemfiles/*
-          - dip bundle install
-          # - dip appraisal install
-      YAML
+    def docker_compose_file_path
+      File.join(gemdock_dir, "docker-compose.yml")
     end
 
     def docker_compose_yml_content(ruby_version: default_ruby_version)
@@ -141,6 +118,8 @@ module GemDock
               - bundler_data:/bundle
             tmpfs:
               - /tmp
+            stdin_open: true
+            tty: true
 
         volumes:
           bundler_data:

--- a/lib/gem_dock/cli.rb
+++ b/lib/gem_dock/cli.rb
@@ -24,56 +24,59 @@ module GemDock
     # end
 
     desc "exec COMMAND [ARGS...]", "Execute arbitrary commands in the container"
+    method_option :ruby_version, type: :string, aliases: "-r", desc: "Ruby version to use (e.g., 3.2.0, 2.7.0)"
     def exec(*args)
       if args.empty?
         puts "Error: No command specified"
-        puts "Usage: gemdock exec <command> [args...]"
+        puts "Usage: gemdock exec [--ruby-version VERSION] <command> [args...]"
         puts "Example: gemdock exec gem install bundler 2.4.22"
+        puts "         gemdock exec --ruby-version 3.2.0 bundle gem myproject"
         puts "         gemdock exec shell  # Opens an interactive shell"
         exit 1
       end
 
-      ensure_initialized
+      ruby_version = options[:ruby_version] || default_ruby_version
+      ensure_initialized(ruby_version)
 
       # Handle special 'shell' command
       if args.first == "shell"
-        run_shell
+        run_shell(ruby_version)
       else
-        run_command(args)
+        run_command(args, ruby_version)
       end
     end
 
     private
 
-    def ensure_initialized
-      unless File.exist?(docker_compose_file_path)
-        puts "GemDock not initialized. Initializing with default Ruby version..."
-        initialize_gemdock
+    def ensure_initialized(ruby_version)
+      compose_file = docker_compose_file_path(ruby_version)
+      unless File.exist?(compose_file)
+        puts "Initializing GemDock with Ruby version #{ruby_version}..."
+        initialize_gemdock(ruby_version)
       end
     end
 
-    def initialize_gemdock(ruby_version = nil)
-      ruby_version ||= default_ruby_version
+    def initialize_gemdock(ruby_version)
       create_gemdock_directory
       create_docker_compose_yml(ruby_version: ruby_version)
       puts "GemDock initialized successfully with Ruby version #{ruby_version}!"
     end
 
-    def run_shell
-      command = build_docker_compose_command(interactive: true)
+    def run_shell(ruby_version)
+      command = build_docker_compose_command(ruby_version, interactive: true)
       command << ["run", "--rm", "gem-app", "/bin/bash"]
       system(*command.flatten)
     end
 
-    def run_command(args)
-      command = build_docker_compose_command
+    def run_command(args, ruby_version)
+      command = build_docker_compose_command(ruby_version)
       command << ["run", "--rm", "gem-app", "bash", "-c", args.join(" ")]
       system(*command.flatten)
     end
 
-    def build_docker_compose_command(interactive: false)
+    def build_docker_compose_command(ruby_version, interactive: false)
       cmd = ["docker", "compose"]
-      cmd << ["-f", docker_compose_file_path]
+      cmd << ["-f", docker_compose_file_path(ruby_version)]
       
       if interactive
         # For interactive shell, we need TTY allocation
@@ -88,8 +91,8 @@ module GemDock
     end
 
     # add an argument to the method to accept Ruby version to use in docker compose file
-    def create_docker_compose_yml(ruby_version: default_ruby_version)
-      path = docker_compose_file_path
+    def create_docker_compose_yml(ruby_version:)
+      path = docker_compose_file_path(ruby_version)
       content = docker_compose_yml_content(ruby_version: ruby_version)
       File.write(path, content)
     end
@@ -98,11 +101,21 @@ module GemDock
       File.join(ENV["HOME"], ".gemdock")
     end
 
-    def docker_compose_file_path
-      File.join(gemdock_dir, "docker-compose.yml")
+    def docker_compose_file_path(ruby_version)
+      # Sanitize version for filename (e.g., "3.3.0" -> "3_3_0")
+      sanitized_version = sanitize_version(ruby_version)
+      File.join(gemdock_dir, "docker-compose-ruby-#{sanitized_version}.yml")
     end
 
-    def docker_compose_yml_content(ruby_version: default_ruby_version)
+    def sanitize_version(version)
+      version.gsub('.', '_').gsub('-', '_')
+    end
+
+    def docker_compose_yml_content(ruby_version:)
+      # Sanitize version for volume name (e.g., "3.3.0" -> "3_3_0")
+      volume_suffix = sanitize_version(ruby_version)
+      volume_name = "bundler_data_ruby_#{volume_suffix}"
+
       <<~YAML
         services:
           gem-app:
@@ -115,14 +128,14 @@ module GemDock
             working_dir: /app
             volumes:
               - ${SOURCE_DIR:-#{Dir.pwd}}:/app:cached
-              - bundler_data:/bundle
+              - #{volume_name}:/bundle
             tmpfs:
               - /tmp
             stdin_open: true
             tty: true
 
         volumes:
-          bundler_data:
+          #{volume_name}:
       YAML
     end
 

--- a/spec/gem_dock/cli_spec.rb
+++ b/spec/gem_dock/cli_spec.rb
@@ -22,46 +22,62 @@ RSpec.describe GemDock::CLI do
     FakeFS.deactivate!
   end
 
-  describe "#init" do
-    it "creates dip.yml and docker-compose.yml" do
-      allow(cli).to receive(:default_ruby_version).and_return("3.2.2")
+  describe "#exec" do
+    context "when docker-compose.yml does not exist" do
+      it "initializes gemdock automatically" do
+        allow(cli).to receive(:default_ruby_version).and_return("3.2.2")
+        allow(cli).to receive(:system).and_return(true)
 
-      cli.init
-      expect(File).to exist(File.join(cli.send(:gemdock_dir), "dip.yml"))
-      expect(File).to exist(File.join(cli.send(:gemdock_dir), "docker-compose.yml"))
-    end
-  end
+        cli.exec("gem", "install", "bundler")
 
-  describe "#update" do
-    it "updates docker-compose.yml file" do
-      allow(cli).to receive(:default_ruby_version).and_return(GemDock::DEFAULT_RUBY_VERSION)
-      cli.init
-
-      allow(cli).to receive(:default_ruby_version).and_return("2.7.0")
-      cli.update
-
-      expect(File).to exist(File.join(cli.send(:gemdock_dir), "docker-compose.yml"))
-      # docker-compose.yml should contain the updated ruby version
-      expect(File.read(File.join(cli.send(:gemdock_dir), "docker-compose.yml"))).to include("2.7.0")
-    end
-  end
-
-  describe "#provision" do
-    it "runs dip provision command" do
-      expect(cli).to receive(:system).with(/DIP_FILE=.*dip provision/)
-      cli.provision
-    end
-  end
-
-  describe "#run" do
-    it "runs dip run command" do
-      expect(cli).to receive(:system).with(/DIP_FILE=.*dip run shell/)
-      cli.run("shell")
+        expect(File).to exist(File.join(cli.send(:gemdock_dir), "docker-compose.yml"))
+      end
     end
 
-    it "passes multiple arguments to dip run command" do
-      expect(cli).to receive(:system).with(/DIP_FILE=.*dip run bundle install/)
-      cli.run("bundle", "install")
+    context "when docker-compose.yml exists" do
+      before do
+        allow(cli).to receive(:default_ruby_version).and_return("3.2.2")
+        cli.send(:initialize_gemdock)
+      end
+
+      it "runs arbitrary commands in container" do
+        expect(cli).to receive(:system) do |*args|
+          command = args.flatten.join(" ")
+          expect(command).to include("docker")
+          expect(command).to include("compose")
+          expect(command).to include("run")
+          expect(command).to include("gem install bundler")
+        end
+
+        cli.exec("gem", "install", "bundler")
+      end
+
+      it "opens interactive shell when 'shell' is passed" do
+        expect(cli).to receive(:system) do |*args|
+          command = args.flatten.join(" ")
+          expect(command).to include("docker")
+          expect(command).to include("compose")
+          expect(command).to include("run")
+          expect(command).to include("/bin/bash")
+        end
+
+        cli.exec("shell")
+      end
+
+      it "runs rspec commands" do
+        expect(cli).to receive(:system) do |*args|
+          command = args.flatten.join(" ")
+          expect(command).to include("rspec spec/")
+        end
+
+        cli.exec("rspec", "spec/")
+      end
+    end
+
+    context "when no command is provided" do
+      it "prints usage information and exits" do
+        expect { cli.exec }.to raise_error(SystemExit)
+      end
     end
   end
 end

--- a/spec/gem_dock/cli_spec.rb
+++ b/spec/gem_dock/cli_spec.rb
@@ -11,11 +11,14 @@ RSpec.describe GemDock::CLI do
     described_class.new
   end
 
+  let(:default_ruby_version) { "3.2.2" }
+
   before do
     FakeFS.activate!
     FileUtils.mkdir_p(Dir.pwd)
     allow(ENV).to receive(:[]).with("THOR_SHELL").and_return(nil)
     allow(ENV).to receive(:[]).with("HOME").and_return("/home/user")
+    allow(cli).to receive(:default_ruby_version).and_return(default_ruby_version)
   end
 
   after do
@@ -24,20 +27,29 @@ RSpec.describe GemDock::CLI do
 
   describe "#exec" do
     context "when docker-compose.yml does not exist" do
-      it "initializes gemdock automatically" do
-        allow(cli).to receive(:default_ruby_version).and_return("3.2.2")
+      it "initializes gemdock automatically with default Ruby version" do
         allow(cli).to receive(:system).and_return(true)
 
         cli.exec("gem", "install", "bundler")
 
-        expect(File).to exist(File.join(cli.send(:gemdock_dir), "docker-compose.yml"))
+        expected_file = File.join(cli.send(:gemdock_dir), "docker-compose-ruby-3_2_2.yml")
+        expect(File).to exist(expected_file)
+      end
+
+      it "initializes gemdock with specified Ruby version" do
+        allow(cli).to receive(:system).and_return(true)
+        cli.options = { ruby_version: "3.1.0" }
+
+        cli.exec("bundle", "install")
+
+        expected_file = File.join(cli.send(:gemdock_dir), "docker-compose-ruby-3_1_0.yml")
+        expect(File).to exist(expected_file)
       end
     end
 
     context "when docker-compose.yml exists" do
       before do
-        allow(cli).to receive(:default_ruby_version).and_return("3.2.2")
-        cli.send(:initialize_gemdock)
+        cli.send(:initialize_gemdock, default_ruby_version)
       end
 
       it "runs arbitrary commands in container" do
@@ -45,6 +57,7 @@ RSpec.describe GemDock::CLI do
           command = args.flatten.join(" ")
           expect(command).to include("docker")
           expect(command).to include("compose")
+          expect(command).to include("docker-compose-ruby-3_2_2.yml")
           expect(command).to include("run")
           expect(command).to include("gem install bundler")
         end
@@ -57,6 +70,7 @@ RSpec.describe GemDock::CLI do
           command = args.flatten.join(" ")
           expect(command).to include("docker")
           expect(command).to include("compose")
+          expect(command).to include("docker-compose-ruby-3_2_2.yml")
           expect(command).to include("run")
           expect(command).to include("/bin/bash")
         end
@@ -71,6 +85,56 @@ RSpec.describe GemDock::CLI do
         end
 
         cli.exec("rspec", "spec/")
+      end
+    end
+
+    context "with --ruby-version flag" do
+      it "uses the specified Ruby version" do
+        allow(cli).to receive(:system).and_return(true)
+        cli.options = { ruby_version: "2.7.0" }
+
+        cli.exec("bundle", "install")
+
+        expected_file = File.join(cli.send(:gemdock_dir), "docker-compose-ruby-2_7_0.yml")
+        expect(File).to exist(expected_file)
+        
+        # Check that the file contains the correct Ruby version
+        content = File.read(expected_file)
+        expect(content).to include("ruby:2.7.0")
+        expect(content).to include("bundler_data_ruby_2_7_0")
+      end
+
+      it "creates version-specific volume names" do
+        allow(cli).to receive(:system).and_return(true)
+        cli.options = { ruby_version: "3.3.0" }
+
+        cli.exec("gem", "list")
+
+        expected_file = File.join(cli.send(:gemdock_dir), "docker-compose-ruby-3_3_0.yml")
+        content = File.read(expected_file)
+        expect(content).to include("bundler_data_ruby_3_3_0")
+      end
+
+      it "allows switching between different Ruby versions" do
+        allow(cli).to receive(:system).and_return(true)
+
+        # First command with Ruby 3.2.0
+        cli.options = { ruby_version: "3.2.0" }
+        cli.exec("bundle", "install")
+
+        file_3_2 = File.join(cli.send(:gemdock_dir), "docker-compose-ruby-3_2_0.yml")
+        expect(File).to exist(file_3_2)
+
+        # Second command with Ruby 2.7.0
+        cli.options = { ruby_version: "2.7.0" }
+        cli.exec("bundle", "install")
+
+        file_2_7 = File.join(cli.send(:gemdock_dir), "docker-compose-ruby-2_7_0.yml")
+        expect(File).to exist(file_2_7)
+
+        # Both files should exist
+        expect(File).to exist(file_3_2)
+        expect(File).to exist(file_2_7)
       end
     end
 


### PR DESCRIPTION
Updates the CLI to use a single `exec` command for running arbitrary commands, simplifying the user interface. This change includes removing the `init`, `update`, `provision`, `run`, and `ls` commands in favor of the `exec` command. Also it updates documentation and example code to reflect the new command structure.